### PR TITLE
PLANET-3325 EN template - Submit button is over the text on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -7637,11 +7637,10 @@ div[class*="__contactDetails"] {
   z-index: 1020;
 }
 
-.sticky {
-  position: --webkit-sticky !important;
-  position: sticky !important;
-  top: 80px;
-  z-index: 1020;
+@media (max-width: 768px) {
+  .sticky {
+    top: 0;
+  }
 }
 
 .ccvv {


### PR DESCRIPTION
For safari browsers `top: 0` needs to be added to the `.sticky` element so that the submit button doesn't hover over the below header.

ref: https://jira.greenpeace.org/browse/PLANET-3325