### PR TITLE
Fixes and cleanup

### DIFF
--- a/main.js
+++ b/main.js
@@ -4,7 +4,9 @@ $(document).ready(function() {
   const new_bg = $('.page-background');
   if (new_bg.length) {
     const img = $(new_bg).attr('src');
-    $('.page-header-background > img').attr('src', img);
+    if (img) {
+      $('.page-header-background > img').attr('src', img);
+    }
     $(new_bg).hide();
   }
 
@@ -130,7 +132,7 @@ $(document).ready(function() {
       }
     });
 
-    $('.menu').click(function() {
+    $('.menu').click(function(event) {
       event.stopPropagation();
       $(this).toggleClass('active');
       $slider.animate({
@@ -142,7 +144,7 @@ $(document).ready(function() {
     var $searchBox = $('#search .search-box');
     var $searchTrigger = $('#search-trigger');
 
-    $searchTrigger.on('click', function (e) {
+    $searchTrigger.on('click', function (event) {
       event.stopPropagation();
       $searchBox.slideToggle().toggleClass('active');
     });
@@ -194,46 +196,46 @@ $(document).ready(function() {
     return false;
   }
 
-  if (p4_site_act_page != '') {
+  if (typeof p4_site_act_page !== 'undefined' && p4_site_act_page != '') {
     $('a[id="act_page"]').attr('href', p4_site_act_page);
   }
-  if (p4_site_explore_page != '') {
+  if (typeof p4_site_explore_page !== 'undefined' && p4_site_explore_page != '') {
     $('a[id="explore_page"]').attr('href', p4_site_explore_page);
   }
-  if (p4_site_donate_btn != '') {
+  if (typeof p4_site_donate_btn !== 'undefined' && p4_site_donate_btn != '') {
     $('a[id="donate_page"]').attr('href', p4_site_donate_btn);
   }
-  if (p4_fb_page != '') {
+  if (typeof p4_fb_page !== 'undefined' && p4_fb_page != '') {
     $('a[id="fb_page"]').attr('href', p4_fb_page);
   }
-  if (p4_twitter_page != '') {
+  if (typeof p4_twitter_page !== 'undefined' && p4_twitter_page != '') {
     $('a[id="tw_page"]').attr('href', p4_twitter_page);
   }
-  if (p4_yt_page != '') {
+  if (typeof p4_yt_page !== 'undefined' && p4_yt_page != '') {
     $('a[id="yt_page"]').attr('href', p4_yt_page);
   }
-  if (p4_instagram_page != '') {
+  if (typeof p4_instagram_page !== 'undefined' && p4_instagram_page != '') {
     $('a[id="insta_page"]').attr('href', p4_instagram_page);
   }
-  if (p4_site_news_page != '') {
+  if (typeof p4_site_news_page !== 'undefined' && p4_site_news_page != '') {
     $('a[id="news_page"]').attr('href', p4_site_news_page);
   }
-  if (p4_site_about_page != '') {
+  if (typeof p4_site_about_page !== 'undefined' && p4_site_about_page != '') {
     $('a[id="about_page"]').attr('href', p4_site_about_page);
   }
-  if (p4_site_jobs_page != '') {
+  if (typeof p4_site_jobs_page !== 'undefined' && p4_site_jobs_page != '') {
     $('a[id="jobs_page"]').attr('href', p4_site_jobs_page);
   }
-  if (p4_site_press_page != '') {
+  if (typeof p4_site_press_page !== 'undefined' && p4_site_press_page != '') {
     $('a[id="press_page"]').attr('href', p4_site_press_page);
   }
-  if (p4_site_privacy_page != '') {
+  if (typeof p4_site_privacy_page !== 'undefined' && p4_site_privacy_page != '') {
     $('a[id="privacy_page"]').attr('href', p4_site_privacy_page);
   }
-  if (p4_community_policy_page != '') {
+  if (typeof p4_community_policy_page !== 'undefined' && p4_community_policy_page != '') {
     $('a[id="community_policy_page"]').attr('href', p4_community_policy_page);
   }
-  if (p4_search_archive_page != '') {
+  if (typeof p4_search_archive_page !== 'undefined' && p4_search_archive_page != '') {
     $('a[id="search_archive_page"]').attr('href', p4_search_archive_page);
   }
 });

--- a/main.js
+++ b/main.js
@@ -1,39 +1,35 @@
-const $document = $(document);
-$document.ready(function () {
-  const $window = $(window);
+$(document).ready(function() {
+
   // Replace page background
-  const $new_bg = $('.page-background');
-  if ($new_bg.length) {
-    const img = $new_bg.attr('src');
-    if (img) {
-      $('.page-header-background > img').attr('src', img);
-    }
-    $new_bg.hide();
+  const new_bg = $('.page-background');
+  if (new_bg.length) {
+    const img = $(new_bg).attr('src');
+    $('.page-header-background > img').attr('src', img);
+    $(new_bg).hide();
   }
 
-  $('.step-info-wrap').click(function () {
-    const $parent = $(this).parent()
-    if ($parent.hasClass('active')) {
-      $parent.removeClass('active');
-    } else {
+  $(".step-info-wrap").click(function() {
+    if ($(this).parent().hasClass('active')) {
+      $(this).parent().removeClass('active');
+    }
+    else {
       $('.col').removeClass('active');
-      $parent.addClass('active');
+      $(this).parent().addClass('active');
     }
   });
 
-  $('.country-select-dropdown').click(function () {
+  $('.country-select-dropdown').click(function() {
     $(this).parent().toggleClass('active-li');
     $('.country-select-box').toggle();
   });
 
-  $('.country-select-box .country-list li').click(function () {
-    const $this = $(this);
-    $this.parents('.country-select-box').find('li').removeClass('active');
-    $this.addClass('active');
+  $('.country-select-box .country-list li').click(function() {
+    $(this).parents('.country-select-box').find('li').removeClass('active');
+    $(this).addClass('active');
   });
 
-  $('div[class*="__contactDetails"]').click(function () {
-    const checkbox = $(this).find('input[type="checkbox"]');
+  $('div[class*="__contactDetails"]').click(function() {
+    let checkbox = $(this).find('input[type="checkbox"]');
     if (checkbox.prop('checked')) {
       checkbox.prop('checked', false);
     } else {
@@ -41,11 +37,11 @@ $document.ready(function () {
     }
   });
 
-  $document.on('click', [
+  $(document).on('click', [
     '.navbar-dropdown-toggle',
     '.country-dropdown-toggle',
     '.navbar-search-toggle',
-  ].join(), function toggleNavDropdown (evt) {
+  ].join(), function toggleNavDropdown(evt) {
     evt.preventDefault();
     evt.stopPropagation();
 
@@ -67,7 +63,7 @@ $document.ready(function () {
     });
   });
 
-  $document.on('click', function closeInactiveMenus (evt) {
+  $(document).on('click', function closeInactiveMenus(evt) {
     var clickedElement = evt.target;
     $('.btn-navbar-toggle[aria-expanded="true"]').each(function (i, button) {
       var $button = $(button);
@@ -79,22 +75,20 @@ $document.ready(function () {
     });
   });
 
-  $document.on('click', '.close-navbar-dropdown', function (evt) {
+  $(document).on('click', '.close-navbar-dropdown', function(evt) {
     evt.preventDefault();
     // Proxy to the main navbar close button
     $('.navbar-dropdown-toggle').trigger('click');
   });
 
 
-  if ($window.width() <= 768) {
-    const $searchBox = $('#search .search-box');
-    const $searchTrigger = $('#search-trigger');
-    let didScroll;
-    let lastScrollTop = 0;
-    const delta = 5;
-    const navbarHeight = $('.top-navigation').outerHeight();
+  if ($(window).width() <= 768) {
+    var didScroll;
+    var lastScrollTop = 0;
+    var delta = 5;
+    var navbarHeight = $('.top-navigation').outerHeight();
 
-    $window.scroll(function () {
+    $(window).scroll(function (event) {
       didScroll = true;
     });
 
@@ -105,33 +99,30 @@ $document.ready(function () {
       }
     }, 250);
 
-    function hasScrolled () {
+    function hasScrolled() {
       var st = $(this).scrollTop();
-      if (Math.abs(lastScrollTop - st) <= delta) {
+      if (Math.abs(lastScrollTop - st) <= delta)
         return;
-      }
       if (st > lastScrollTop && st > navbarHeight) {
         $('.top-navigation').removeClass('nav-down').addClass('nav-up');
       } else {
-        if (st + $window.height() < $document.height()) {
+        if (st + $(window).height() < $(document).height()) {
           $('.top-navigation').removeClass('nav-up').addClass('nav-down');
         }
       }
       lastScrollTop = st;
     }
 
-    const $slider = $('.mobile-menus');
+    var $slider = $('.mobile-menus');
 
-    $document.click(function () {
-      const $menu = $('.menu');
-      if ($menu.hasClass('active')) {
+    $(document).click(function() {
+      if ($('.menu').hasClass('active')) {
         //Hide the menus if visible
         $slider.animate({
-          left: parseInt($slider.css('left'), 10) == 0
-            ? -320
-            : 0
+          left: parseInt($slider.css('left'), 10) == 0 ?
+            -320 : 0
         });
-        $menu.removeClass('active');
+        $('.menu').removeClass('active');
       }
       if ($('.search-box').hasClass('active')) {
         //Hide the search if visible
@@ -139,7 +130,7 @@ $document.ready(function () {
       }
     });
 
-    $('.menu').click(function (event) {
+    $('.menu').click(function() {
       event.stopPropagation();
       $(this).toggleClass('active');
       $slider.animate({
@@ -148,7 +139,10 @@ $document.ready(function () {
       });
     });
 
-    $searchTrigger.on('click', function (event) {
+    var $searchBox = $('#search .search-box');
+    var $searchTrigger = $('#search-trigger');
+
+    $searchTrigger.on('click', function (e) {
       event.stopPropagation();
       $searchBox.slideToggle().toggleClass('active');
     });
@@ -157,87 +151,89 @@ $document.ready(function () {
   $('.en__field__label').hide();
   $('.en__field__input--radio').next().show();
 
-  $('input, select')
-    .not('[type="radio"]')
-    .not('[type="checkbox"]')
-    .addClass('form-control');
-  $('input, select').not('[type="checkbox"]').parent().not('.nav-search-wrap').addClass('form-group');
+  $('input').addClass('form-control');
+  $('input').parent().addClass('form-group');
+  $('select').addClass('form-control');
+  $('select').parent().addClass('form-group');
+  $('input[type="radio"]').removeClass('form-control');
+  $('.nav-search-wrap').removeClass('form-group');
 
   $('input[name="transaction.ccvv"]').addClass('ccvv');
 
-  $('.en__field__element--text').css('display', 'block');
+  $('input[type="checkbox"]').removeClass('form-control');
+  $('input[type="checkbox"]').parent().removeClass('form-group');
 
-  $('.en__field').css('padding-bottom', '0');
+  $('.en__field__element--text').css("display", "block");
 
-  $('.en__field__input--checkbox').parent().find('label')
-    .css('display', 'block')
-    .addClass('form-check-label')
-    .css('margin-top', '-25px')
-    .css('margin-left', '25px');
+  $('.en__field').css("padding-bottom", "0px");
+
+  $('.en__field__input--checkbox').parent().find('label').css("display", "block");
+  $('.en__field__input--checkbox').parent().find('label').addClass("form-check-label");
+  $('.en__field__input--checkbox').parent().find('label').css("margin-top", "-25px");
+  $('.en__field__input--checkbox').parent().find('label').css("margin-left", "25px");
 
   $('.en__submit').find('button').addClass('btn btn-primary btn-block');
 
   $('.en__field--text').each(function () {
-    const $this = $(this)
-    const input = $this.find('input');
-    const label = $this.find('label');
-    const labelText = label.text();
+    var input = $(this).find('input');
+    var label = $(this).find('label');
+    var labelText = label.text();
     input.attr('placeholder', labelText);
   });
 
   // Navbar & Footer links
-  var p4_site_url = 'https://www.greenpeace.org/international/';
-  var p4_site_act_page = 'https://www.greenpeace.org/international/act/';
-  var p4_site_explore_page = 'https://www.greenpeace.org/international/explore/';
-  var p4_site_donate_btn = 'https://secured.greenpeace.org/international/en/supportus/?_ga=2.256767427.937523877.1515410303-280997801.1515410303';
+  var p4_site_url = "https://www.greenpeace.org/international/";
+  var p4_site_act_page = "https://www.greenpeace.org/international/act/";
+  var p4_site_explore_page = "https://www.greenpeace.org/international/explore/";
+  var p4_site_donate_btn = "https://secured.greenpeace.org/international/en/supportus/?_ga=2.256767427.937523877.1515410303-280997801.1515410303";
 
 
-  function search_form () {
+  function search_form() {
     var searchme = $("#searchme").val();
     window.location = p4_site_url + "?orderby=relevant&s=" + searchme;
     return false;
   }
 
-  if (typeof p4_site_act_page !== 'undefined' && p4_site_act_page != '') {
-    $('a#act_page').attr('href', p4_site_act_page);
+  if (p4_site_act_page != '') {
+    $('a[id="act_page"]').attr('href', p4_site_act_page);
   }
-  if (typeof p4_site_explore_page !== 'undefined' && p4_site_explore_page != '') {
-    $('a#explore_page').attr('href', p4_site_explore_page);
+  if (p4_site_explore_page != '') {
+    $('a[id="explore_page"]').attr('href', p4_site_explore_page);
   }
-  if (typeof p4_site_donate_btn !== 'undefined' && p4_site_donate_btn != '') {
-    $('a#donate_page').attr('href', p4_site_donate_btn);
+  if (p4_site_donate_btn != '') {
+    $('a[id="donate_page"]').attr('href', p4_site_donate_btn);
   }
-  if (typeof p4_fb_page !== 'undefined' && p4_fb_page != '') {
-    $('a#fb_page').attr('href', p4_fb_page);
+  if (p4_fb_page != '') {
+    $('a[id="fb_page"]').attr('href', p4_fb_page);
   }
-  if (typeof p4_twitter_page !== 'undefined' && p4_twitter_page != '') {
-    $('a#tw_page').attr('href', p4_twitter_page);
+  if (p4_twitter_page != '') {
+    $('a[id="tw_page"]').attr('href', p4_twitter_page);
   }
-  if (typeof p4_yt_page !== 'undefined' && p4_yt_page != '') {
-    $('a#yt_page').attr('href', p4_yt_page);
+  if (p4_yt_page != '') {
+    $('a[id="yt_page"]').attr('href', p4_yt_page);
   }
-  if (typeof p4_instagram_page !== 'undefined' && p4_instagram_page != '') {
-    $('a#insta_page').attr('href', p4_instagram_page);
+  if (p4_instagram_page != '') {
+    $('a[id="insta_page"]').attr('href', p4_instagram_page);
   }
-  if (typeof p4_site_news_page !== 'undefined' && p4_site_news_page != '') {
-    $('a#news_page').attr('href', p4_site_news_page);
+  if (p4_site_news_page != '') {
+    $('a[id="news_page"]').attr('href', p4_site_news_page);
   }
-  if (typeof p4_site_about_page !== 'undefined' && p4_site_about_page != '') {
-    $('a#about_page').attr('href', p4_site_about_page);
+  if (p4_site_about_page != '') {
+    $('a[id="about_page"]').attr('href', p4_site_about_page);
   }
-  if (typeof p4_site_jobs_page !== 'undefined' && p4_site_jobs_page != '') {
-    $('a#jobs_page').attr('href', p4_site_jobs_page);
+  if (p4_site_jobs_page != '') {
+    $('a[id="jobs_page"]').attr('href', p4_site_jobs_page);
   }
-  if (typeof p4_site_press_page !== 'undefined' && p4_site_press_page != '') {
-    $('a#press_page').attr('href', p4_site_press_page);
+  if (p4_site_press_page != '') {
+    $('a[id="press_page"]').attr('href', p4_site_press_page);
   }
-  if (typeof p4_site_privacy_page !== 'undefined' && p4_site_privacy_page != '') {
-    $('a#privacy_page').attr('href', p4_site_privacy_page);
+  if (p4_site_privacy_page != '') {
+    $('a[id="privacy_page"]').attr('href', p4_site_privacy_page);
   }
-  if (typeof p4_community_policy_page !== 'undefined' && p4_community_policy_page != '') {
-    $('a#community_policy_page').attr('href', p4_community_policy_page);
+  if (p4_community_policy_page != '') {
+    $('a[id="community_policy_page"]').attr('href', p4_community_policy_page);
   }
-  if (typeof p4_search_archive_page !== 'undefined' && p4_search_archive_page != '') {
-    $('a#search_archive_page').attr('href', p4_search_archive_page);
+  if (p4_search_archive_page != '') {
+    $('a[id="search_archive_page"]').attr('href', p4_search_archive_page);
   }
 });

--- a/main.js
+++ b/main.js
@@ -1,35 +1,39 @@
-$(document).ready(function() {
-
+const $document = $(document);
+$document.ready(function () {
+  const $window = $(window);
   // Replace page background
-  const new_bg = $('.page-background');
-  if (new_bg.length) {
-    const img = $(new_bg).attr('src');
-    $('.page-header-background > img').attr('src', img);
-    $(new_bg).hide();
+  const $new_bg = $('.page-background');
+  if ($new_bg.length) {
+    const img = $new_bg.attr('src');
+    if (img) {
+      $('.page-header-background > img').attr('src', img);
+    }
+    $new_bg.hide();
   }
 
-  $(".step-info-wrap").click(function() {
-    if ($(this).parent().hasClass('active')) {
-      $(this).parent().removeClass('active');
-    }
-    else {
+  $('.step-info-wrap').click(function () {
+    const $parent = $(this).parent()
+    if ($parent.hasClass('active')) {
+      $parent.removeClass('active');
+    } else {
       $('.col').removeClass('active');
-      $(this).parent().addClass('active');
+      $parent.addClass('active');
     }
   });
 
-  $('.country-select-dropdown').click(function() {
+  $('.country-select-dropdown').click(function () {
     $(this).parent().toggleClass('active-li');
     $('.country-select-box').toggle();
   });
 
-  $('.country-select-box .country-list li').click(function() {
-    $(this).parents('.country-select-box').find('li').removeClass('active');
-    $(this).addClass('active');
+  $('.country-select-box .country-list li').click(function () {
+    const $this = $(this);
+    $this.parents('.country-select-box').find('li').removeClass('active');
+    $this.addClass('active');
   });
 
-  $('div[class*="__contactDetails"]').click(function() {
-    let checkbox = $(this).find('input[type="checkbox"]');
+  $('div[class*="__contactDetails"]').click(function () {
+    const checkbox = $(this).find('input[type="checkbox"]');
     if (checkbox.prop('checked')) {
       checkbox.prop('checked', false);
     } else {
@@ -37,11 +41,11 @@ $(document).ready(function() {
     }
   });
 
-  $(document).on('click', [
+  $document.on('click', [
     '.navbar-dropdown-toggle',
     '.country-dropdown-toggle',
     '.navbar-search-toggle',
-  ].join(), function toggleNavDropdown(evt) {
+  ].join(), function toggleNavDropdown (evt) {
     evt.preventDefault();
     evt.stopPropagation();
 
@@ -63,7 +67,7 @@ $(document).ready(function() {
     });
   });
 
-  $(document).on('click', function closeInactiveMenus(evt) {
+  $document.on('click', function closeInactiveMenus (evt) {
     var clickedElement = evt.target;
     $('.btn-navbar-toggle[aria-expanded="true"]').each(function (i, button) {
       var $button = $(button);
@@ -75,20 +79,22 @@ $(document).ready(function() {
     });
   });
 
-  $(document).on('click', '.close-navbar-dropdown', function(evt) {
+  $document.on('click', '.close-navbar-dropdown', function (evt) {
     evt.preventDefault();
     // Proxy to the main navbar close button
     $('.navbar-dropdown-toggle').trigger('click');
   });
 
 
-  if ($(window).width() <= 768) {
-    var didScroll;
-    var lastScrollTop = 0;
-    var delta = 5;
-    var navbarHeight = $('.top-navigation').outerHeight();
+  if ($window.width() <= 768) {
+    const $searchBox = $('#search .search-box');
+    const $searchTrigger = $('#search-trigger');
+    let didScroll;
+    let lastScrollTop = 0;
+    const delta = 5;
+    const navbarHeight = $('.top-navigation').outerHeight();
 
-    $(window).scroll(function (event) {
+    $window.scroll(function () {
       didScroll = true;
     });
 
@@ -99,30 +105,33 @@ $(document).ready(function() {
       }
     }, 250);
 
-    function hasScrolled() {
+    function hasScrolled () {
       var st = $(this).scrollTop();
-      if (Math.abs(lastScrollTop - st) <= delta)
+      if (Math.abs(lastScrollTop - st) <= delta) {
         return;
+      }
       if (st > lastScrollTop && st > navbarHeight) {
         $('.top-navigation').removeClass('nav-down').addClass('nav-up');
       } else {
-        if (st + $(window).height() < $(document).height()) {
+        if (st + $window.height() < $document.height()) {
           $('.top-navigation').removeClass('nav-up').addClass('nav-down');
         }
       }
       lastScrollTop = st;
     }
 
-    var $slider = $('.mobile-menus');
+    const $slider = $('.mobile-menus');
 
-    $(document).click(function() {
-      if ($('.menu').hasClass('active')) {
+    $document.click(function () {
+      const $menu = $('.menu');
+      if ($menu.hasClass('active')) {
         //Hide the menus if visible
         $slider.animate({
-          left: parseInt($slider.css('left'), 10) == 0 ?
-            -320 : 0
+          left: parseInt($slider.css('left'), 10) == 0
+            ? -320
+            : 0
         });
-        $('.menu').removeClass('active');
+        $menu.removeClass('active');
       }
       if ($('.search-box').hasClass('active')) {
         //Hide the search if visible
@@ -130,7 +139,7 @@ $(document).ready(function() {
       }
     });
 
-    $('.menu').click(function() {
+    $('.menu').click(function (event) {
       event.stopPropagation();
       $(this).toggleClass('active');
       $slider.animate({
@@ -139,10 +148,7 @@ $(document).ready(function() {
       });
     });
 
-    var $searchBox = $('#search .search-box');
-    var $searchTrigger = $('#search-trigger');
-
-    $searchTrigger.on('click', function (e) {
+    $searchTrigger.on('click', function (event) {
       event.stopPropagation();
       $searchBox.slideToggle().toggleClass('active');
     });
@@ -151,89 +157,87 @@ $(document).ready(function() {
   $('.en__field__label').hide();
   $('.en__field__input--radio').next().show();
 
-  $('input').addClass('form-control');
-  $('input').parent().addClass('form-group');
-  $('select').addClass('form-control');
-  $('select').parent().addClass('form-group');
-  $('input[type="radio"]').removeClass('form-control');
-  $('.nav-search-wrap').removeClass('form-group');
+  $('input, select')
+    .not('[type="radio"]')
+    .not('[type="checkbox"]')
+    .addClass('form-control');
+  $('input, select').not('[type="checkbox"]').parent().not('.nav-search-wrap').addClass('form-group');
 
   $('input[name="transaction.ccvv"]').addClass('ccvv');
 
-  $('input[type="checkbox"]').removeClass('form-control');
-  $('input[type="checkbox"]').parent().removeClass('form-group');
+  $('.en__field__element--text').css('display', 'block');
 
-  $('.en__field__element--text').css("display", "block");
+  $('.en__field').css('padding-bottom', '0');
 
-  $('.en__field').css("padding-bottom", "0px");
-
-  $('.en__field__input--checkbox').parent().find('label').css("display", "block");
-  $('.en__field__input--checkbox').parent().find('label').addClass("form-check-label");
-  $('.en__field__input--checkbox').parent().find('label').css("margin-top", "-25px");
-  $('.en__field__input--checkbox').parent().find('label').css("margin-left", "25px");
+  $('.en__field__input--checkbox').parent().find('label')
+    .css('display', 'block')
+    .addClass('form-check-label')
+    .css('margin-top', '-25px')
+    .css('margin-left', '25px');
 
   $('.en__submit').find('button').addClass('btn btn-primary btn-block');
 
   $('.en__field--text').each(function () {
-    var input = $(this).find('input');
-    var label = $(this).find('label');
-    var labelText = label.text();
+    const $this = $(this)
+    const input = $this.find('input');
+    const label = $this.find('label');
+    const labelText = label.text();
     input.attr('placeholder', labelText);
   });
 
   // Navbar & Footer links
-  var p4_site_url = "https://www.greenpeace.org/international/";
-  var p4_site_act_page = "https://www.greenpeace.org/international/act/";
-  var p4_site_explore_page = "https://www.greenpeace.org/international/explore/";
-  var p4_site_donate_btn = "https://secured.greenpeace.org/international/en/supportus/?_ga=2.256767427.937523877.1515410303-280997801.1515410303";
+  var p4_site_url = 'https://www.greenpeace.org/international/';
+  var p4_site_act_page = 'https://www.greenpeace.org/international/act/';
+  var p4_site_explore_page = 'https://www.greenpeace.org/international/explore/';
+  var p4_site_donate_btn = 'https://secured.greenpeace.org/international/en/supportus/?_ga=2.256767427.937523877.1515410303-280997801.1515410303';
 
 
-  function search_form() {
+  function search_form () {
     var searchme = $("#searchme").val();
     window.location = p4_site_url + "?orderby=relevant&s=" + searchme;
     return false;
   }
 
-  if (p4_site_act_page != '') {
-    $('a[id="act_page"]').attr('href', p4_site_act_page);
+  if (typeof p4_site_act_page !== 'undefined' && p4_site_act_page != '') {
+    $('a#act_page').attr('href', p4_site_act_page);
   }
-  if (p4_site_explore_page != '') {
-    $('a[id="explore_page"]').attr('href', p4_site_explore_page);
+  if (typeof p4_site_explore_page !== 'undefined' && p4_site_explore_page != '') {
+    $('a#explore_page').attr('href', p4_site_explore_page);
   }
-  if (p4_site_donate_btn != '') {
-    $('a[id="donate_page"]').attr('href', p4_site_donate_btn);
+  if (typeof p4_site_donate_btn !== 'undefined' && p4_site_donate_btn != '') {
+    $('a#donate_page').attr('href', p4_site_donate_btn);
   }
-  if (p4_fb_page != '') {
-    $('a[id="fb_page"]').attr('href', p4_fb_page);
+  if (typeof p4_fb_page !== 'undefined' && p4_fb_page != '') {
+    $('a#fb_page').attr('href', p4_fb_page);
   }
-  if (p4_twitter_page != '') {
-    $('a[id="tw_page"]').attr('href', p4_twitter_page);
+  if (typeof p4_twitter_page !== 'undefined' && p4_twitter_page != '') {
+    $('a#tw_page').attr('href', p4_twitter_page);
   }
-  if (p4_yt_page != '') {
-    $('a[id="yt_page"]').attr('href', p4_yt_page);
+  if (typeof p4_yt_page !== 'undefined' && p4_yt_page != '') {
+    $('a#yt_page').attr('href', p4_yt_page);
   }
-  if (p4_instagram_page != '') {
-    $('a[id="insta_page"]').attr('href', p4_instagram_page);
+  if (typeof p4_instagram_page !== 'undefined' && p4_instagram_page != '') {
+    $('a#insta_page').attr('href', p4_instagram_page);
   }
-  if (p4_site_news_page != '') {
-    $('a[id="news_page"]').attr('href', p4_site_news_page);
+  if (typeof p4_site_news_page !== 'undefined' && p4_site_news_page != '') {
+    $('a#news_page').attr('href', p4_site_news_page);
   }
-  if (p4_site_about_page != '') {
-    $('a[id="about_page"]').attr('href', p4_site_about_page);
+  if (typeof p4_site_about_page !== 'undefined' && p4_site_about_page != '') {
+    $('a#about_page').attr('href', p4_site_about_page);
   }
-  if (p4_site_jobs_page != '') {
-    $('a[id="jobs_page"]').attr('href', p4_site_jobs_page);
+  if (typeof p4_site_jobs_page !== 'undefined' && p4_site_jobs_page != '') {
+    $('a#jobs_page').attr('href', p4_site_jobs_page);
   }
-  if (p4_site_press_page != '') {
-    $('a[id="press_page"]').attr('href', p4_site_press_page);
+  if (typeof p4_site_press_page !== 'undefined' && p4_site_press_page != '') {
+    $('a#press_page').attr('href', p4_site_press_page);
   }
-  if (p4_site_privacy_page != '') {
-    $('a[id="privacy_page"]').attr('href', p4_site_privacy_page);
+  if (typeof p4_site_privacy_page !== 'undefined' && p4_site_privacy_page != '') {
+    $('a#privacy_page').attr('href', p4_site_privacy_page);
   }
-  if (p4_community_policy_page != '') {
-    $('a[id="community_policy_page"]').attr('href', p4_community_policy_page);
+  if (typeof p4_community_policy_page !== 'undefined' && p4_community_policy_page != '') {
+    $('a#community_policy_page').attr('href', p4_community_policy_page);
   }
-  if (p4_search_archive_page != '') {
-    $('a[id="search_archive_page"]').attr('href', p4_search_archive_page);
+  if (typeof p4_search_archive_page !== 'undefined' && p4_search_archive_page != '') {
+    $('a#search_archive_page').attr('href', p4_search_archive_page);
   }
 });


### PR DESCRIPTION
Our unsubscribe page uses this script, and the page was breaking because "p4_fb_page" was undefined, making the `attr` function throw an error which wasn't caught, interrupting script execution. This change inserts guards to avoid using `attr` with an undefined value. I took the occasion to remove all instances I found where a function could be called on an undefined variable. This includes places using `event.preventDefault()` or `event.stopPropagation()` without naming the first argument to the event listener function, effectively making this `undefined.preventDefault()` or `undefined.stopPropagation().