### PR TITLE
PLANET-6091 Add XXL breakpoint

### DIFF
--- a/style.css
+++ b/style.css
@@ -4901,9 +4901,15 @@ blockquote.twitter-tweet a:focus {
   }
 }
 
-@media (min-width: 1480px) {
+@media (min-width: 1200px) {
   .page-template {
     width: 1140px;
+  }
+}
+
+@media (min-width: 1920px) {
+  .page-template {
+    width: 1320px;
   }
 }
 


### PR DESCRIPTION
### Description

See [PLANET-6091](https://jira.greenpeace.org/browse/PLANET-6091)

This is to align the donation pages with the new breakpoint, even though it will not solve it for all NROs, it's a start. This commit also fixes the XL breakpoint value, which should be 1200px instead of 1480px. There are lots of other properties in the file that use the `1480px` value, but it would be a lot of changes so for now I'm only fixing the width.

Related PRs: 
- [master-theme](https://github.com/greenpeace/planet4-master-theme/pull/1508)
- [blocks](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/716)